### PR TITLE
Complex scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ our new set of minimum goals.
 
 ### Fixes:
 - [x] Game ends only when at least one player has an empty rack, *and* the bag is empty
-- [ ] Score calculation takes adjacent words/letters into consideration, even if not played
+- [x] Score calculation takes adjacent words/letters into consideration, even if not played
   on that turn
 - [ ] End-of-game scores subtract the score of any tiles remaining on each player's rack
 - [ ] Allow players to place tiles with capital letters and space (for blank tiles)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ our new set of minimum goals.
 - [x] Game ends only when at least one player has an empty rack, *and* the bag is empty
 - [x] Score calculation takes adjacent words/letters into consideration, even if not played
   on that turn
-- [ ] End-of-game scores subtract the score of any tiles remaining on each player's rack
+- [x] End-of-game scores subtract the score of any tiles remaining on each player's rack
 - [ ] Allow players to place tiles with capital letters and space (for blank tiles)
 
 ### Stretch Goals:

--- a/src/Controller.hs
+++ b/src/Controller.hs
@@ -7,7 +7,7 @@ import           Brick hiding (Result)
 import qualified Brick.Types as T
 import           Control.Monad.IO.Class (MonadIO(liftIO))
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Graphics.Vty as V
 import           Model
 import           Model.Bag
@@ -187,7 +187,7 @@ endTurn s = do
   let nextPlayerKey = getNextPlayerKey s
   -- If the bag is empty and the player has used all their tiles, end the game
   if isBagEmpty bag && isRackEmpty rack'
-    then return (End board, playerMap', nextPlayerKey, bag')
+    then return (End board, M.map finalizePlayerScore playerMap', nextPlayerKey, bag')
     else return (Cont board, playerMap', nextPlayerKey, bag')
 
 -- | Updates the result of the game

--- a/src/Controller.hs
+++ b/src/Controller.hs
@@ -176,7 +176,7 @@ endTurn s = do
   -- PlayedRack is a [(Tile, BoardPos)] so the board pos info can be used
   -- to compute which tiles are on bonus board positions and also search fromEnum
   -- a board position the four directions for the tiles it is connected to.
-  let newScore      = updateScore (extractTiles playedRack) currScore
+  let newScore      = updateScore playedRack board currScore
   -- Refill Rack
   (bag', rack')    <- fillRack rack bag
   -- Clear playedRack

--- a/src/Model/Board.hs
+++ b/src/Model/Board.hs
@@ -21,13 +21,18 @@ module Model.Board
 
   -- Board API
   , initBoard
+  , isOccupied
   , getTile
+  , getTileUnsafe
   , putTile
   , deleteTile
+  , getAllOccPositions
 )
   where
 
 import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Maybe as Maybe
 import           Model.Tile 
 import           Prelude hiding (init)
 
@@ -68,9 +73,18 @@ data Result a
 initBoard :: Board
 initBoard = M.empty
 
+-- | Determine whether there's a tile at the given position
+isOccupied :: Board -> BoardPos -> Bool
+isOccupied b pos = Maybe.isJust $ getTile b pos
+
 -- | Gets a Tile on the board at the position
 getTile :: Board -> BoardPos -> Maybe Tile 
 getTile board pos = M.lookup pos board
+
+-- | Get the tile on the board at this position. Throws an error if there is no
+-- tile there.
+getTileUnsafe :: Board -> BoardPos -> Tile
+getTileUnsafe board pos = board M.! pos
 
 -- | Puts a Tile on the board at the position
 putTile :: Board -> Tile -> BoardPos -> Result Board
@@ -83,3 +97,53 @@ putTile board lett pos = case M.lookup pos board of
 -- | Delete a tile at a board position
 deleteTile :: Board -> BoardPos -> Result Board
 deleteTile board boardpos = Cont (M.delete boardpos board)
+
+
+-- These functions used to calculate complex scores, acccounting for contiguous tiles
+-- in cardinal directions from the current play
+
+-- | Get all continguous occupied positions in cardinal directions from this pos,
+-- including the current position
+getAllOccPositions :: Board -> BoardPos -> S.Set BoardPos
+getAllOccPositions b pos = S.unions
+                            [ getUpOccPositions    b pos
+                            , getDownOccPositions  b pos
+                            , getLeftOccPositions  b pos
+                            , getRightOccPositions b pos
+                            ]
+
+-- | Get contiguous occupied positions directly up from this pos, including
+-- the current position
+getUpOccPositions :: Board -> BoardPos -> S.Set BoardPos
+getUpOccPositions b pos@(BoardPos r c)
+  | r == 0 || not (isOccupied b pos) = S.empty
+  | otherwise = S.union (S.singleton pos) (getUpOccPositions b upPos)
+  where
+    upPos = BoardPos (r - 1) c
+
+-- | Get contiguous occupied positions directly down from this pos, including
+-- the current position
+getDownOccPositions :: Board -> BoardPos -> S.Set BoardPos
+getDownOccPositions b pos@(BoardPos r c)
+  | r == boardDim - 1 || not (isOccupied b pos) = S.empty
+  | otherwise = S.union (S.singleton pos) (getDownOccPositions b downPos)
+  where
+    downPos = BoardPos (r + 1) c
+
+-- | Get contiguous occupied positions directly left of this pos, including
+-- the current position
+getLeftOccPositions :: Board -> BoardPos -> S.Set BoardPos
+getLeftOccPositions b pos@(BoardPos r c)
+  | c == 0  || not (isOccupied b pos) = S.empty
+  | otherwise = S.union (S.singleton pos) (getLeftOccPositions b leftPos)
+  where
+    leftPos = BoardPos r (c - 1)
+
+-- | Get contiguous occupied positions directly right of this pos, including
+-- the current position
+getRightOccPositions :: Board -> BoardPos -> S.Set BoardPos
+getRightOccPositions b pos@(BoardPos r c)
+  | c == boardDim - 1 || not (isOccupied b pos) = S.empty
+  | otherwise = S.union (S.singleton pos) (getRightOccPositions b rightPos)
+  where
+    rightPos = BoardPos r (c + 1)

--- a/src/Model/Board.hs
+++ b/src/Model/Board.hs
@@ -60,7 +60,7 @@ data BoardPos = BoardPos
   { pRow :: Int
   , pCol :: Int
   }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 -- | A Result is the definition of if a put succeed or fails on the board
 data Result a 
@@ -81,8 +81,8 @@ isOccupied b pos = Maybe.isJust $ getTile b pos
 getTile :: Board -> BoardPos -> Maybe Tile 
 getTile board pos = M.lookup pos board
 
--- | Get the tile on the board at this position. Throws an error if there is no
--- tile there.
+-- | Get the tile on the board at this position. Throws an error if the position
+-- is unoccupied.
 getTileUnsafe :: Board -> BoardPos -> Tile
 getTileUnsafe board pos = board M.! pos
 
@@ -116,8 +116,9 @@ getAllOccPositions b pos = S.unions
 -- the current position
 getUpOccPositions :: Board -> BoardPos -> S.Set BoardPos
 getUpOccPositions b pos@(BoardPos r c)
-  | r == 0 || not (isOccupied b pos) = S.empty
-  | otherwise = S.union (S.singleton pos) (getUpOccPositions b upPos)
+  | not (isOccupied b pos) = S.empty
+  | r == 0                 = S.singleton pos
+  | otherwise              = S.union (S.singleton pos) (getUpOccPositions b upPos)
   where
     upPos = BoardPos (r - 1) c
 
@@ -125,8 +126,9 @@ getUpOccPositions b pos@(BoardPos r c)
 -- the current position
 getDownOccPositions :: Board -> BoardPos -> S.Set BoardPos
 getDownOccPositions b pos@(BoardPos r c)
-  | r == boardDim - 1 || not (isOccupied b pos) = S.empty
-  | otherwise = S.union (S.singleton pos) (getDownOccPositions b downPos)
+  | not (isOccupied b pos) = S.empty
+  | r == boardDim - 1      = S.singleton pos
+  | otherwise              = S.union (S.singleton pos) (getDownOccPositions b downPos)
   where
     downPos = BoardPos (r + 1) c
 
@@ -134,8 +136,9 @@ getDownOccPositions b pos@(BoardPos r c)
 -- the current position
 getLeftOccPositions :: Board -> BoardPos -> S.Set BoardPos
 getLeftOccPositions b pos@(BoardPos r c)
-  | c == 0  || not (isOccupied b pos) = S.empty
-  | otherwise = S.union (S.singleton pos) (getLeftOccPositions b leftPos)
+  | not (isOccupied b pos) = S.empty
+  | c == 0                 = S.singleton pos
+  | otherwise              = S.union (S.singleton pos) (getLeftOccPositions b leftPos)
   where
     leftPos = BoardPos r (c - 1)
 
@@ -143,7 +146,8 @@ getLeftOccPositions b pos@(BoardPos r c)
 -- the current position
 getRightOccPositions :: Board -> BoardPos -> S.Set BoardPos
 getRightOccPositions b pos@(BoardPos r c)
-  | c == boardDim - 1 || not (isOccupied b pos) = S.empty
-  | otherwise = S.union (S.singleton pos) (getRightOccPositions b rightPos)
+  | not (isOccupied b pos) = S.empty
+  | c == boardDim - 1      = S.singleton pos
+  | otherwise              = S.union (S.singleton pos) (getRightOccPositions b rightPos)
   where
     rightPos = BoardPos r (c + 1)

--- a/src/Model/Player.hs
+++ b/src/Model/Player.hs
@@ -13,6 +13,7 @@ module Model.Player
     , initPlayer
     , initPlayersMap
     , initCurrPlayerKey
+    , finalizePlayerScore
 
     -- PlayerMap API
     , getPlayer
@@ -21,10 +22,11 @@ module Model.Player
 )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import           Model.PlayedRack
 import           Model.Rack
 import           Model.Score
+import           Model.Tile
 
 -- A player has a name.
 data Player = MkPlayer 
@@ -56,6 +58,13 @@ getPlayerName player = plName (snd player)
 
 getPlayerScore :: (Int, Player) -> Score
 getPlayerScore player = plScore (snd player)
+
+-- | Calculate the final score for a player at the end of the game. Subtracts
+-- the score of any tiles left in the player's rack from their final score.
+finalizePlayerScore :: Player -> Player
+finalizePlayerScore (MkPlayer name rack pr sc) = MkPlayer name [] pr sc'
+  where
+    sc' = sc - (sum $ map getTileScore rack)
 
 getPlayer :: PlayerMap -> Int -> Player
 getPlayer playerMap = (playerMap M.!)

--- a/src/Model/Score.hs
+++ b/src/Model/Score.hs
@@ -42,9 +42,9 @@ updateScore :: PlayedRack -> Board -> Score -> Score
 updateScore pr b sc = sc + calcNewScore pr b
 
 calcNewScore :: PlayedRack -> Board -> Score
-calcNewScore pr b = sum $ S.map getTileScore scoredTiles
+calcNewScore pr b = sum $ map getTileScore scoredTiles
   where
-    scoredTiles = S.map (getTileUnsafe b) $ calcScoredPositions pr b
+    scoredTiles = map (getTileUnsafe b) $ S.toList (calcScoredPositions pr b)
 
 -- | Calculate the positions that should be scored for the given played rack.
 -- This includes all played positions, and any adjacent positions that are

--- a/src/Model/Score.hs
+++ b/src/Model/Score.hs
@@ -76,7 +76,7 @@ calcNewScore pr b = sum $ map getTileScore scoredTiles
 -- In addition, the tiles `E`, `E` played on this turn are each counted twice
 -- (once in each direction). You can think of this as scoring up each \"word\"
 -- formed by this play: `NEED`, `EE`, and `EX`. So the final score is
--- (1 + 1 + 1 + 2) + (1 + 1) + (1 + 9) = 16.
+-- (1 + 1 + 1 + 2) + (1 + 1) + (1 + 8) = 16.
 calcScoredPositions :: PlayedRack -> Board -> [BoardPos]
 calcScoredPositions pr b = playedPos ++ (S.toList $ scoredPosSet playedPos b)
   where


### PR DESCRIPTION
Calculates the score associated with a play according to the full Scrabble rules, i.e.:
- counts all tiles in all "words" formed during the play, including tiles that were not played in that turn
- double-counts played tiles that form words in both directions (up-down and left-right)